### PR TITLE
remove dead code, fix flag assignment, remove redundant select statement

### DIFF
--- a/config/redis.go
+++ b/config/redis.go
@@ -2,4 +2,5 @@ package config
 
 type RedisConfig struct {
 	ServerAddr string `yaml:"server_addr"`
+	Password   string `yaml:"password"`
 }

--- a/main.go
+++ b/main.go
@@ -100,7 +100,8 @@ func main() {
 	waitSeconds := config.RelayServerConfig.GracefulShutdownWaitSeconds
 	log.Printf("Sig %v received, shutting down, graceful shutdown wait: %v seconds\n", sig, waitSeconds)
 
+	relayServer.Shutdown()
+
 	<-time.After(time.Duration(waitSeconds) * time.Second)
 
-	relayServer.Shutdown()
 }

--- a/main.go
+++ b/main.go
@@ -47,14 +47,6 @@ func startMetricServer(config *config.MetricConfig) {
 	}()
 }
 
-func configOverwriteFromCmdline(defaultConfig config.Config) config.Config {
-	config := config.Config{}
-
-	flag.Parse()
-
-	return config
-}
-
 func parseCmdlineAndLoadConfig() config.Config {
 	cmdlineConfig := config.Config{}
 	configFilePath := flag.String("config", "", "config file")
@@ -71,6 +63,10 @@ func parseCmdlineAndLoadConfig() config.Config {
 	// overwrite with cmdline config
 	if listen := cmdlineConfig.RelayServerConfig.Listen; listen != "" {
 		fileConfig.RelayServerConfig.Listen = listen
+	}
+
+	if serverAddr := cmdlineConfig.RedisServerConfig.ServerAddr; serverAddr != "" {
+		fileConfig.RedisServerConfig.ServerAddr = serverAddr
 	}
 
 	return fileConfig
@@ -103,8 +99,8 @@ func main() {
 	sig := <-sigChan
 	waitSeconds := config.RelayServerConfig.GracefulShutdownWaitSeconds
 	log.Printf("Sig %v received, shutting down, graceful shutdown wait: %v seconds\n", sig, waitSeconds)
-	select {
-	case <-time.After(time.Duration(waitSeconds) * time.Second):
-	}
+
+	<-time.After(time.Duration(waitSeconds) * time.Second)
+
 	relayServer.Shutdown()
 }

--- a/relay/relayserver.go
+++ b/relay/relayserver.go
@@ -2,6 +2,8 @@ package relay
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -44,6 +46,9 @@ func NewRelayServer(config *config.RelayConfig, wsServer *WsServer) *relayServer
 
 func (rs *relayServer) Run() {
 	err := rs.httpServer.ListenAndServe()
+	if err != nil && errors.Is(err, http.ErrServerClosed) {
+		return
+	}
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)
 	}
@@ -51,6 +56,9 @@ func (rs *relayServer) Run() {
 
 // Shutdown Gracefully shutdown the relay server
 func (rs *relayServer) Shutdown() {
-	rs.httpServer.Shutdown(context.TODO())
+	err := rs.httpServer.Shutdown(context.TODO())
+	if err != nil {
+		fmt.Println(err)
+	}
 	rs.wsServer.Shutdown()
 }

--- a/relay/wsserver.go
+++ b/relay/wsserver.go
@@ -57,7 +57,7 @@ func NewWSServer(config *config.Config) *WsServer {
 	}
 	ws.redisConn = redis.NewClient(&redis.Options{
 		Addr:     config.RedisServerConfig.ServerAddr,
-		Password: "",
+		Password: config.RedisServerConfig.Password,
 		DB:       0,
 	})
 	ws.redisSubConn = ws.redisConn.Subscribe(context.TODO())


### PR DESCRIPTION
I noticed the README's `-redis_config.server_addr` was not actually overriding the value in the config file.

- Remove dead code
- Fix redis address flag assignment
- Remove redundant select statement
- Add password support
